### PR TITLE
gitlab-ci: Add first version of action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This is a collection of reusable Github Actions for repositories in the `pulp-platform` organization. PULP (Parallel Ultra-Low-Power) is an open-source multi-core computing platform developed in ongoing collaboration between ETH Zurich and the University of Bologna.
 
+## How to use
+
+There is a subdirectory for each action with a README providing setup instructions.
+
+To use an action in your workflow, you must add its subdirectory to the repository path in the `uses` clause, e.g.:
+
+```yaml
+uses: pulp-platform/pulp-actions/gitlab-ci@v1
+```
+
 ## License
 
 The code in this repository is licensed under Apache 2.0 (see LICENSE).

--- a/gitlab-ci/README.md
+++ b/gitlab-ci/README.md
@@ -1,0 +1,38 @@
+# Gitlab CI
+
+This action mirrors a repository to a Gitlab remote, then polls for a CI pipeline and checks its completion status. The action passes if the mirror push succeeds, a pipeline is spawned, and that pipeline succeeds within a configurable timeout period.
+
+## Preparation
+
+First, create a Gitlab mirror repo and grant your Github upstream repo developer access to it:
+
+1. Create a *blank target repo* on your Gitlab instance. For PULP members, use the `github-mirror` group, preserve the upstream repo name, and disable unnecessary Gitlab features in *Settings* → *General*.
+
+2. Obtain a *project access token* to the Gitlab mirror. In *Settings* → *Access Tokens*, create a token called `github-ci` with role *Developer*, a reasonable expiry date, and all available scopes. After generation, copy the token from the top hidden text field to a temporary location; it will become inaccessible once you leave the page.
+
+3. Add the project access token as a *secret* to your Github upstream repository. Go to *Settings* → *Secrets and variables* → *Actions* and add the token as a new repository secret called `GITLAB_TOKEN`. Again, the secret will become write-only once you leave the page.
+
+## Action usage
+
+Once this is done, you can add the action to your desired upstream workflow. We suggest creating a standalone workflow with appropriate trigger rules for this, for example:
+
+```yaml
+name: gitlab-ci
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  gitlab-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Gitlab CI
+        uses: pulp-platform/pulp-actions/gitlab-ci@v1
+        with:
+          domain: iis-git.ee.ethz.ch
+          repo: github-mirror/cheshire
+          token: ${{ secrets.GITLAB_TOKEN }}
+```
+
+Optional inputs controlling the Gitlab API version and timeouts are available; see `action.yml`.
+
+Be sure to add a `.gitlab-ci.yml` to your repo; otherwise, the action will time out waiting for a pipeline to spawn on new commits, resulting in failure.

--- a/gitlab-ci/action.yml
+++ b/gitlab-ci/action.yml
@@ -1,0 +1,73 @@
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+name: 'Gitlab CI'
+description: 'Mirror repository to a Gitlab remote and check CI pipeline status'
+
+inputs:
+  # Mandatory arguments
+  domain:
+    description: 'Domain of remote Gitlab instance'
+    required: true
+  repo:
+    description: 'Full group path of mirror repository'
+    required: true
+  token:
+    description: 'Access token for mirror repository'
+    required: true
+  # Optional arguments (sensible defaults below)
+  api-version:
+    description: 'Version of Gitlab API to use'
+    required: true
+    default: "v4"
+  retry-count:
+    description: 'Number of polls before pipeline spawn is deemed a failure'
+    required: true
+    default: 12
+  retry-period:
+    description: 'Period of polls in seconds before pipeline spawns'
+    required: true
+    default: 10
+  poll-count:
+    description: 'Number of polls before running pipeline is deemed a failure'
+    required: true
+    default: 720
+  poll-period:
+    description: 'Period of polls in seconds while pipeline is running'
+    required: true
+    default: 10
+
+runs:
+  using: "composite"
+  steps:
+    - name: Full checkout
+      shell: bash
+      run: git clone --bare https://token:${{ github.token }}@github.com/${{ github.repository }} ${{ github.workspace }}
+    - name: Push to mirror
+      shell: bash
+      run: |
+        git remote add gitlab https://token:${{ inputs.token }}@${{ inputs.domain }}/${{ inputs.repo }}
+        git push --force --mirror gitlab
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Install Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+    - name: Install Python requirements
+      shell: bash
+      # PIP has very noisy, uncollapsible output, making following script output hard to read
+      run: pip install --disable-pip-version-check --quiet --progress-bar off requests urllib3
+    - name: Poll results
+      shell: bash
+      # Pull request SHAs point to a merged commit that is not mirrored
+      run: |
+        cd ${{ github.action_path }}
+        export SHA=${{ github.sha }}
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then export SHA=${{ github.event.pull_request.head.sha }}; fi
+        ./gitlab-ci.py $SHA ${{ inputs.token }} ${{ inputs.domain }} ${{ inputs.repo }} ${{ inputs.api-version }} ${{ inputs.retry-count }} ${{ inputs.retry-period }} ${{ inputs.poll-count }} ${{ inputs.poll-period }}

--- a/gitlab-ci/gitlab-ci.py
+++ b/gitlab-ci/gitlab-ci.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Paul Scheffler <paulsc@iis.ee.ethz.ch>
+# Nils Wistoff <nwistoff@iis.ee.ethz.ch>
+
+import os
+import sys
+import time
+import requests
+import urllib.parse
+
+
+def main(sha: str, token: str, domain: str, repo: str, api_version: str,
+         retry_count: int, retry_period: int, poll_count: int, poll_period: int):
+    # Derive pipeline URL
+    pipelines = f'https://{domain}/api/{api_version}/projects/{urllib.parse.quote_plus(repo)}/pipelines'
+
+    # Wait for pipeline to spawn
+    for i in range(1, retry_count+1):
+        response = requests.get(pipelines, headers={'PRIVATE-TOKEN': token}).json()
+        try:
+            next(p for p in response if p['sha'] == sha)
+            break
+        except StopIteration:
+            print(f'[{i*retry_period}s] No pipeline yet for SHA {sha}')
+            time.sleep(retry_period)
+    else:
+        print(f'[{retry_count*retry_period}s] Pipeline spawn timeout')
+        return 2
+
+    # Wait for pipeline to complete
+    for i in range(1, poll_count+1):
+        response = requests.get(pipelines, headers={'PRIVATE-TOKEN': token}).json()
+        pipeline = next(p for p in response if p['sha'] == sha)
+        if pipeline['status'] == 'success':
+            print(f'[{i*poll_period}s] Pipeline success! See {pipeline["web_url"]}')
+            return 0
+        elif pipeline['status'] in ('failed', 'canceled', 'skipped'):
+            print(f'[{i*poll_period}s] Pipeline failure! See {pipeline["web_url"]}')
+            return 1
+        print(f'[{i*poll_period}s] Pipeline status: {pipeline["status"]}')
+        time.sleep(poll_period)
+    else:
+        print(f'[{poll_count*poll_period}s] Pipeline completion timeout! See {pipeline["web_url"]}')
+        return 3
+
+
+if __name__ == '__main__':
+    sys.exit(main(*(int(a) if a.isdigit() else a for a in sys.argv[1:])))


### PR DESCRIPTION
This action mirrors a repository to a Gitlab remote, then polls for a CI pipeline and checks its completion status. The action passes if the mirror push succeeds, a pipeline is spawned, and that pipeline succeeds within a configurable timeout period.