### PR TITLE
Add bender-vendor-up-to-date action

### DIFF
--- a/bender-vendor-up-to-date/README.md
+++ b/bender-vendor-up-to-date/README.md
@@ -1,0 +1,22 @@
+# Bender vendor up-to-date
+
+This action runs `bender vendor diff` and checks if all vendored dependencies are up-to-date, i.e. the state of the checked-in dependencies matches their upstream ref with the local patches applied.
+
+## Action usage
+
+Simply add the action to your desired upstream workflow. Optionally specify a bender version using `bender-version` (default: latest). We suggest creating a standalone workflow with appropriate trigger rules for this, for example:
+
+```yaml
+name: bender-vendor-up-to-date
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  bender-vendor-up-to-date:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check bender vendor up-to-date
+        uses: pulp-platform/pulp-actions/bender-vendor-up-to-date@v2
+        with:
+          bender-version: 0.27.1
+```

--- a/bender-vendor-up-to-date/action.yml
+++ b/bender-vendor-up-to-date/action.yml
@@ -1,0 +1,31 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Nils Wistoff <nwistoff@iis.ee.ethz.ch>
+
+name: 'Bender vendor up-to-date'
+description: 'Check if the bender-vendored dependencies are up-to-date.'
+
+inputs:
+  # Optional argument
+  bender-version:
+    description: 'Bender version to install (default: latest)'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Install bender
+      uses: pulp-platform/pulp-actions/bender-install@v2
+      with:
+        version: ${{ inputs.bender-version }}
+    - name: Check bender vendor up-to-date
+      shell: bash
+      run: |
+        bender vendor diff --err_on_diff


### PR DESCRIPTION
This action runs `bender vendor diff` and checks if all vendored dependencies are up-to-date, i.e. the state of the checked-in dependencies matches their upstream ref with the local patches applied.
