### PR TITLE
Add riscv-gcc-install action, correct lint-license tool path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ To use an action in your workflow, you must add its subdirectory to the reposito
 uses: pulp-platform/pulp-actions/gitlab-ci@v1
 ```
 
+## Recommended third-party actions
+
+We deliberately do not recreate or wrap functionality already provided by well-designed existing actions. Here is a list of third-party actions recommended for `pulp-platform` repositories:
+
+* Linting:
+    * C/C++: `DoozyX/clang-format-lint-action`
+    * (System)Verilog: `chipsalliance/verible-linter-action`
+    * Python: `py-actions/flake8`
+    * Rust: `mbrobbel/rustfmt-check`
+
 ## License
 
 The code in this repository is licensed under Apache 2.0 (see LICENSE).

--- a/lint-license/README.md
+++ b/lint-license/README.md
@@ -7,8 +7,8 @@ This action installs and runs lowRISC's [license linter](https://github.com/lowR
 Simply add the action to your desired upstream workflow. Indicate the license header with the `license` argument, and whether this is a regex with `match_regex` (defaults to true). You can optionally specify:
 
 * `exclude_paths`: path expressions to exclude
-* `linters-revison`: The revision of `lowRISC/misc-linters` to use
-* `matcher`: An alternative matcher used to report violations
+* `linters_revison`: the revision of `lowRISC/misc-linters` to use
+* `matcher`: an alternative matcher used to report violations
 
 Here is an example workflow using this action:
 

--- a/lint-license/action.yml
+++ b/lint-license/action.yml
@@ -44,16 +44,17 @@ runs:
     - name: Intall lowRISC linters
       shell: bash
       run: |
-        cd ${{ github.workspace }}
+        mkdir -p ${{ runner.temp }}/pulp-actions/lint-license
+        cd ${{ runner.temp }}/pulp-actions/lint-license
         git clone https://github.com/lowRISC/misc-linters.git
         cd misc-linters
         git checkout ${{ inputs.linters_revision }}
     - name: Generate config
       shell: bash
-      run: ${{ github.action_path }}/gen_config.py "${{ github.workspace }}/cfg.hjson" ${{ inputs.match_regex }} "${{ inputs.license }}" "${{ inputs.exclude_paths }}"
+      run: ${{ github.action_path }}/gen_config.py "${{ runner.temp }}/pulp-actions/lint-license/cfg.hjson" ${{ inputs.match_regex }} "${{ inputs.license }}" "${{ inputs.exclude_paths }}"
     - name: Check license
       shell: bash
       run: |
         echo "::add-matcher::${{ github.action_path }}/matcher.json"
-        bash -c "set -e; ${{ github.workspace }}/misc-linters/licence-checker/licence-checker.py --config \"${{ github.workspace }}/cfg.hjson\""
+        bash -c "set -e; ${{ runner.temp }}/pulp-actions/lint-license/misc-linters/licence-checker/licence-checker.py --config \"${{ runner.temp }}/pulp-actions/lint-license/cfg.hjson\""
         echo "::remove-matcher owner=pulp-actions-lint-license-matcher::"

--- a/riscv-gcc-install/README.md
+++ b/riscv-gcc-install/README.md
@@ -1,28 +1,24 @@
 # RISC-V GCC install
 
-This action downloads and installs a nightly build of the RISC-V GCC toolchain provided [here](). Not that as of writing, only Ubuntu LTS builds are provided.
+This action downloads and installs a nightly build of the RISC-V GCC toolchain provided [here](https://github.com/riscv-collab/riscv-gnu-toolchain/releases). Not that as of writing, only Ubuntu LTS builds are provided.
 
 ## Action usage
 
 Simply add the action to your desired upstream workflow. You can specify the `distro`, `nightly-date`, and `target`, which all have sensible defaults. Here is an example workflow using this action:
 
 ```yaml
-name: lint-license
+name: riscv-gcc-install
 
 on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
-  lint-license:
-    runs-on: ubuntu-latest
+  riscv-gcc-install:
+    runs-on: ubuntu-22.04
     steps:
-      - name: lint license
-        uses: pulp-platform/pulp-actions/lint-license@v2
+      - name: RISC-V GCC install
+        uses: pulp-platform/pulp-actions/riscv-gcc-install@v2
         with:
-          license: |
-            Copyright (\d{4}(-\d{4})?\s)?(ETH Zurich and University of Bologna|lowRISC contributors).
-            (Solderpad Hardware License, Version 0.51|Licensed under the Apache License, Version 2.0), see LICENSE for details.
-            SPDX-License-Identifier: (SHL-0.51|Apache-2.0)
-          exclude_paths: |
-            sw/include/regs/*.h
-            sw/include/geninfo.h
+          distro: ubuntu-22.04
+          nightly-date: '2023.03.14'
+          target: riscv64-elf
 ```

--- a/riscv-gcc-install/README.md
+++ b/riscv-gcc-install/README.md
@@ -1,0 +1,28 @@
+# RISC-V GCC install
+
+This action downloads and installs a nightly build of the RISC-V GCC toolchain provided [here](). Not that as of writing, only Ubuntu LTS builds are provided.
+
+## Action usage
+
+Simply add the action to your desired upstream workflow. You can specify the `distro`, `nightly-date`, and `target`, which all have sensible defaults. Here is an example workflow using this action:
+
+```yaml
+name: lint-license
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  lint-license:
+    runs-on: ubuntu-latest
+    steps:
+      - name: lint license
+        uses: pulp-platform/pulp-actions/lint-license@v2
+        with:
+          license: |
+            Copyright (\d{4}(-\d{4})?\s)?(ETH Zurich and University of Bologna|lowRISC contributors).
+            (Solderpad Hardware License, Version 0.51|Licensed under the Apache License, Version 2.0), see LICENSE for details.
+            SPDX-License-Identifier: (SHL-0.51|Apache-2.0)
+          exclude_paths: |
+            sw/include/regs/*.h
+            sw/include/geninfo.h
+```

--- a/riscv-gcc-install/action.yml
+++ b/riscv-gcc-install/action.yml
@@ -1,0 +1,39 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+name: 'RISC-V GCC install'
+description: 'Installs a nightly build of the RISC-V GCC toolchain.'
+
+inputs:
+  # Optional arguments (sensible defaults below)
+  nightly-date:
+    description: 'Date of nightly release (default: 2023.03.14)'
+    required: true
+    default: '2023.03.14'
+  distro:
+    description: 'Identifier of distribution (default: ubuntu-22.04)'
+    required: true
+    default: 'ubuntu-22.04'
+  target:
+    description: 'Target architecture and platform (default: riscv64-elf)'
+    required: true
+    default: 'riscv64-elf'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install RISC-V GCC toolchain
+      shell: bash
+      run: |
+        mkdir -p ${{ runner.temp }}/pulp-actions/riscv-gcc-install
+        cd ${{ runner.temp }}/pulp-actions/riscv-gcc-install
+        RISCV_GCC_NAME=riscv-gcc-${{ inputs.nightly-date }}-${{ inputs.distro }}-${{ inputs.target }}
+        curl -Ls -o ${RISCV_GCC_NAME}.tar.gz https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${{ inputs.nightly-date }}/${{ inputs.target }}-${{ inputs.distro }}-nightly-${{ inputs.nightly-date }}-nightly.tar.gz
+        sudo chmod 777 ${RISCV_GCC_NAME}.tar.gz
+        sudo mkdir -p ${RISCV_GCC_NAME} && sudo chmod 777 ${RISCV_GCC_NAME}
+        tar -C ${RISCV_GCC_NAME} -xf ${RISCV_GCC_NAME}.tar.gz --strip-components=1
+        rm ${RISCV_GCC_NAME}.tar.gz
+        echo "PATH=$PATH:${RISCV_GCC_NAME}/bin" >> ${GITHUB_ENV}

--- a/riscv-gcc-install/action.yml
+++ b/riscv-gcc-install/action.yml
@@ -28,12 +28,13 @@ runs:
     - name: Install RISC-V GCC toolchain
       shell: bash
       run: |
-        mkdir -p ${{ runner.temp }}/pulp-actions/riscv-gcc-install
-        cd ${{ runner.temp }}/pulp-actions/riscv-gcc-install
+        RISCV_GCC_PATH=${{ runner.temp }}/pulp-actions/riscv-gcc-install
+        mkdir -p ${RISCV_GCC_PATH}
+        cd ${RISCV_GCC_PATH}
         RISCV_GCC_NAME=riscv-gcc-${{ inputs.nightly-date }}-${{ inputs.distro }}-${{ inputs.target }}
         curl -Ls -o ${RISCV_GCC_NAME}.tar.gz https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${{ inputs.nightly-date }}/${{ inputs.target }}-${{ inputs.distro }}-nightly-${{ inputs.nightly-date }}-nightly.tar.gz
         sudo chmod 777 ${RISCV_GCC_NAME}.tar.gz
         sudo mkdir -p ${RISCV_GCC_NAME} && sudo chmod 777 ${RISCV_GCC_NAME}
         tar -C ${RISCV_GCC_NAME} -xf ${RISCV_GCC_NAME}.tar.gz --strip-components=1
         rm ${RISCV_GCC_NAME}.tar.gz
-        echo "PATH=$PATH:${RISCV_GCC_NAME}/bin" >> ${GITHUB_ENV}
+        echo "PATH=$PATH:${RISCV_GCC_PATH}/${RISCV_GCC_NAME}/bin" >> ${GITHUB_ENV}


### PR DESCRIPTION
This MR:

* Adds the `riscv-gcc-install` action, which installs a nightly RISC-V GCC build.
* Corrects an issue in the `lint-license-tool` action cloning its code into the triggering repository's tree, potentially interfering with other steps (as this is a constructive fix only, no version increment is required).
* Add some recommended third-party actions to `README`.