### PR TITLE
lint-license: Add patches for lowRISC/misc-linters

### DIFF
--- a/lint-license/action.yml
+++ b/lint-license/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Revision of `lowRISC/misc-linters` to use'
     required: true
     default: '20220921_01'
+  patches:
+    description: 'A list of patches from the patches/ directory to apply to lowRISC/misc-linters'
+    required: true
+    default: ''
 
 runs:
   using: "composite"
@@ -49,6 +53,9 @@ runs:
         git clone https://github.com/lowRISC/misc-linters.git
         cd misc-linters
         git checkout ${{ inputs.linters_revision }}
+        git config user.email "colluca@iis.ee.ethz.ch"
+        git config user.name "Luca Colagrande"
+        ${{ github.action_path }}/apply_patches.py ${{ runner.temp }}/pulp-actions/lint-license/misc-linters ${{ inputs.patches }} --patch-dir=${{ github.action_path }}/patches
     - name: Generate config
       shell: bash
       run: ${{ github.action_path }}/gen_config.py "${{ runner.temp }}/pulp-actions/lint-license/cfg.hjson" ${{ inputs.match_regex }} "${{ inputs.license }}" "${{ inputs.exclude_paths }}"

--- a/lint-license/apply_patches.py
+++ b/lint-license/apply_patches.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Luca Colagrande <colluca@iis.ee.ethz.ch>
+
+import os
+import argparse
+from pathlib import Path
+
+
+def main():
+    # Argument parsing
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'repo',
+        help='Path to Git repository to patch',
+    )
+    parser.add_argument(
+        'patches',
+        nargs='+',
+        help='List of patches to apply')
+    parser.add_argument(
+        '--patch-dir',
+        action='store',
+        help='(Optional) Path to look for the patches in')
+    args = parser.parse_args()
+    patches = args.patches
+    repo = args.repo
+    patch_dir = args.patch_dir
+
+    # Apply patches
+    for patch in patches:
+        patchfile = Path(patch)
+        if patch_dir:
+            patchfile = Path(patch_dir) / patchfile
+        os.system(f'git -C {repo} am {patchfile}')
+
+
+if __name__ == '__main__':
+    main()

--- a/lint-license/patches/0001-Allow-hash-comments-in-assembly.patch
+++ b/lint-license/patches/0001-Allow-hash-comments-in-assembly.patch
@@ -1,0 +1,27 @@
+From 8f0ef9a7b9af190e49ee74adc6232f43374012e3 Mon Sep 17 00:00:00 2001
+From: Luca Colagrande <luca.colagrande3@gmail.com>
+Date: Wed, 19 Apr 2023 14:05:28 +0200
+Subject: [PATCH] Allow hash comments in assembly
+
+---
+ licence-checker/licence-checker.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/licence-checker/licence-checker.py b/licence-checker/licence-checker.py
+index e863f94..6263f50 100755
+--- a/licence-checker/licence-checker.py
++++ b/licence-checker/licence-checker.py
+@@ -142,8 +142,8 @@ COMMENT_CHARS = [
+     # Software Files
+     ([".c", ".h", ".inc", ".cc", ".cpp"], SLASH_SLASH),  # C, C++
+     ([".def"], SLASH_SLASH),  # C, C++ X-Include List Declaration Files
+-    ([".S"], [SLASH_SLASH, SLASH_STAR]),  # Assembly (With Preprocessing)
+-    ([".s"], SLASH_STAR),  # Assembly (Without Preprocessing)
++    ([".S"], [SLASH_SLASH, SLASH_STAR, HASH]),  # Assembly (With Preprocessing)
++    ([".s"], [SLASH_STAR, HASH]),  # Assembly (Without Preprocessing)
+     ([".ld"], SLASH_STAR),  # Linker Scripts
+     ([".rs"], SLASH_SLASH),  # Rust
+     ([".go"], SLASH_SLASH),  # Golang
+-- 
+2.28.0
+


### PR DESCRIPTION
I opened a [PR](https://github.com/lowRISC/misc-linters/pull/31) to upstream a patch to lowRISC's licence-checker. In the meantime this PR provides the patch in the [`patches/`](https://github.com/pulp-platform/pulp-actions/tree/patch/license-checker/lint-license/patches) folder.

It also provides a Python script (and invokes it in the Github action) to apply selected patches from the [`patches/`](https://github.com/pulp-platform/pulp-actions/tree/patch/license-checker/lint-license/patches) folder if requested as an input to the Github action. By default no patch should be applied.