### PR TITLE
lint-license: Make `patches` argument optional

### DIFF
--- a/lint-license/action.yml
+++ b/lint-license/action.yml
@@ -30,7 +30,7 @@ inputs:
     default: '20220921_01'
   patches:
     description: 'A list of patches from the patches/ directory to apply to lowRISC/misc-linters'
-    required: true
+    required: false
     default: ''
 
 runs:

--- a/lint-license/apply_patches.py
+++ b/lint-license/apply_patches.py
@@ -20,7 +20,7 @@ def main():
     )
     parser.add_argument(
         'patches',
-        nargs='+',
+        nargs='*',
         help='List of patches to apply')
     parser.add_argument(
         '--patch-dir',
@@ -32,11 +32,12 @@ def main():
     patch_dir = args.patch_dir
 
     # Apply patches
-    for patch in patches:
-        patchfile = Path(patch)
-        if patch_dir:
-            patchfile = Path(patch_dir) / patchfile
-        os.system(f'git -C {repo} am {patchfile}')
+    if patches:
+        for patch in patches:
+            patchfile = Path(patch)
+            if patch_dir:
+                patchfile = Path(patch_dir) / patchfile
+            os.system(f'git -C {repo} am {patchfile}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Redefines the `patches` argument to be optional and correctly handles the case where no patches are supplied.

This PR fixes https://github.com/pulp-platform/pulp-actions/issues/16.