### PR TITLE
README: Recommend `diff-porcelain` for Git-up-to-date checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ We deliberately do not recreate or wrap functionality already provided by well-d
     * Python: `py-actions/flake8`
     * Rust: `mbrobbel/rustfmt-check`
     * YAML: `ibiqlik/action-yamllint`
+* Miscellaneous:
+    * Git up-to-date: `mmontes11/diff-porcelain`
 
 ## License
 


### PR DESCRIPTION
The Snitch cluster repo uses the `diff-porcelain` action to check that the Git repository is in a clean state:
https://github.com/pulp-platform/snitch_cluster/blob/4652c6b05886757c5cbe3dfe77c196dcd71e08e7/.github/workflows/lint.yml#L41-L57

Perhaps other repos use this action too, or implement a custom solution themselves. In an attempt to uniformize these efforts, I propose to add this action (or other preferred approach) to the README.
