### PR TITLE
treewide: Work around pip caching without `requirements.txt`

### DIFF
--- a/gitlab-ci/action.yml
+++ b/gitlab-ci/action.yml
@@ -55,6 +55,11 @@ runs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
+    - name: Work around setup-python cache issue
+      # see https://github.com/actions/setup-python/issues/807
+      if: hashFiles('**/requirements.txt', '**/pyproject.toml') == ''
+      shell: bash
+      run: touch ./requirements.txt
     - name: Install Python
       uses: actions/setup-python@v5
       with:

--- a/integrate/action.yml
+++ b/integrate/action.yml
@@ -45,6 +45,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Work around setup-python cache issue
+      # see https://github.com/actions/setup-python/issues/807
+      if: hashFiles('**/requirements.txt', '**/pyproject.toml') == ''
+      shell: bash
+      run: touch ./requirements.txt
     - name: Install Python
       uses: actions/setup-python@v5
       with:

--- a/lint-license/action.yml
+++ b/lint-license/action.yml
@@ -38,6 +38,11 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Work around setup-python cache issue
+      # see https://github.com/actions/setup-python/issues/807
+      if: hashFiles('**/requirements.txt', '**/pyproject.toml') == ''
+      shell: bash
+      run: touch ./requirements.txt
     - name: Install Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Fixes #20. See https://github.com/actions/setup-python/issues/807.