### PR TITLE
slang: Add variable to pass reviewdog check name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project (post v2.1.0) adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `slang`: Add `reviewdog-name` variable to optionally pass a name for the reviewdog check.
 
 ## 2.5.0 - 2026-03-31
 ### Added

--- a/slang/README.md
+++ b/slang/README.md
@@ -7,6 +7,9 @@ This action builds a project with [slang](https://github.com/MikePopoloski/slang
 Simply add the action to your desired upstream workflow. Pass `secrets.GITHUB_TOKEN` as the `token` argument and specify the [slang flags](https://sv-lang.com/command-line-ref.html) with `slang-flags` (at minimum a file list). You can optionally specify:
 
 * `reviewdog-reporter`: the reviewdog reporter to use (defaults to `github-check`)
+* `reviewdog-name`: the name for the reviewdog check (defaults to `github-check`). Must be unique per job instance.
+
+> :warning: If you run multiple instances of this action within the same job (e.g., in a matrix), make sure to give `reviewdog-name` a unique value for each instance (e.g., derived from the matrix variables). Otherwise, the instances may overwrite each other's results.
 
 Here is an example workflow using this action:
 

--- a/slang/action.yml
+++ b/slang/action.yml
@@ -19,6 +19,9 @@ inputs:
       description: 'Reporter to use for reviewdog. Defaults to github-check.'
       required: false
       default: 'github-check'
+   reviewdog-name:
+      required: false
+      default: 'slang'
 
 runs:
    using: 'composite'
@@ -47,7 +50,7 @@ runs:
         run: |
           uv run ${{ github.action_path }}/slang_to_rdjson.py slang_diags.json \
             | reviewdog -f=rdjson \
-                -name=slang \
+                -name=${{ inputs.reviewdog-name }} \
                 -reporter=${{ inputs.reviewdog-reporter }} \
                 -filter-mode=nofilter \
                 -fail-level=error

--- a/slang/action.yml
+++ b/slang/action.yml
@@ -20,12 +20,10 @@ inputs:
       required: false
       default: 'github-check'
    reviewdog-name:
-      description: 'Name for the reviewdog reporter run. Must be unique per job run, otherwise multiple
-         reporters (e.g., spawned by a matrix) may overwrite each others results. To avoid such collisions,
-         the default behavior is to suffix the check_run_id (but other unique names can be chosen instead
-         for better readibility)'
+      description: 'Name for the reviewdog check. Must be unique per job instance; otherwise multiple
+         reporters (e.g., spawned by a matrix) may overwrite each others results. Defaults to slang.'
       required: false
-      default: 'slang-${{ job.check_run_id }}'
+      default: 'slang'
 
 runs:
    using: 'composite'

--- a/slang/action.yml
+++ b/slang/action.yml
@@ -20,8 +20,12 @@ inputs:
       required: false
       default: 'github-check'
    reviewdog-name:
+      description: 'Name for the reviewdog reporter run. Must be unique per job run, otherwise multiple
+         reporters (e.g., spawned by a matrix) may overwrite each others results. To avoid such collisions,
+         the default behavior is to suffix the check_run_id (but other unique names can be chosen instead
+         for better readibility)'
       required: false
-      default: 'slang'
+      default: 'slang-${{ job.check_run_id }}'
 
 runs:
    using: 'composite'


### PR DESCRIPTION
If a job runs multiple instances of the `slang` action (e.g., in a matrix), the reviewdog check results may override each other. Fix this by adding an optional `reviewdog-name` variable to specify a unique name for the check and add a corresponding note in the README. Tested on https://github.com/niwis/FlooNoC/commit/8fb132715070b03baf8adf2e43dca1c9db370d96.

cc @fischeti 