### PR TITLE
slang: Support pyslang/slang v11 and pin the pyslang version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project (post v2.1.0) adheres to [Semantic Versioning](http://semver.or
 ## Unreleased
 ### Added
 - `slang`: Add `reviewdog-name` variable to optionally pass a name for the reviewdog check.
+- `slang`: Add `pyslang-version` variable to pin the `pyslang` (and thereby slang) version.
+
+### Fixed
+- `slang`: Support pyslang/slang v11 by handling its reorganized module layout (`Driver` and `CommandLineOptions` moved to the `pyslang.driver` submodule), and pin `pyslang` to a known-good release (default `11.0.0`) instead of always installing the latest.
 
 ## 2.5.0 - 2026-03-31
 ### Added

--- a/slang/README.md
+++ b/slang/README.md
@@ -8,8 +8,11 @@ Simply add the action to your desired upstream workflow. Pass `secrets.GITHUB_TO
 
 * `reviewdog-reporter`: the reviewdog reporter to use (defaults to `github-check`)
 * `reviewdog-name`: the name for the reviewdog check (defaults to `github-check`). Must be unique per job instance.
+* `pyslang-version`: the exact `pyslang` version to install (defaults to a known-good release).
 
 > :warning: If you run multiple instances of this action within the same job (e.g., in a matrix), make sure to give `reviewdog-name` a unique value for each instance (e.g., derived from the matrix variables). Otherwise, the instances may overwrite each other's results.
+
+> :information_source: This action runs slang through [`pyslang`](https://pypi.org/project/pyslang/), which bundles the slang engine and is released in lockstep with it (pyslang `X.Y` ships slang `X.Y`). The `pyslang-version` input therefore pins **both** the pyslang and the slang version. It defaults to a known-good release for reproducible runs; `run_slang.py` supports both pyslang v10 and v11. To move to a newer slang, verify `run_slang.py` against it and bump `pyslang-version`.
 
 Here is an example workflow using this action:
 

--- a/slang/action.yml
+++ b/slang/action.yml
@@ -24,6 +24,14 @@ inputs:
          reporters (e.g., spawned by a matrix) may overwrite each others results. Defaults to slang.'
       required: false
       default: 'slang'
+   pyslang-version:
+      description: 'pyslang version to install, as an exact version number (e.g. "11.0.0").
+         pyslang bundles the slang engine and is released in lockstep with it, so this single
+         value pins both the pyslang and the slang version. Pinned to a known-good release for
+         reproducible runs and to avoid surprise breakage from upstream API changes. run_slang.py
+         currently supports pyslang v10 and v11; bump this only after verifying a newer release.'
+      required: false
+      default: '11.0.0'
 
 runs:
    using: 'composite'
@@ -37,7 +45,7 @@ runs:
 
       - name: Run slang
         shell: bash
-        run: uv run --with pyslang ${{ github.action_path }}/run_slang.py "${{ inputs.slang-flags }}" slang_diags.json
+        run: uv run --with "pyslang==${{ inputs.pyslang-version }}" ${{ github.action_path }}/run_slang.py "${{ inputs.slang-flags }}" slang_diags.json
 
       - name: Setup reviewdog
         uses: reviewdog/action-setup@v1

--- a/slang/run_slang.py
+++ b/slang/run_slang.py
@@ -10,7 +10,13 @@
 
 import sys
 
-from pyslang import CommandLineOptions, Driver
+try:
+    # pyslang >= 11 reorganized its bindings into submodules matching the slang
+    # C++ namespaces, so Driver and CommandLineOptions live under pyslang.driver.
+    from pyslang.driver import CommandLineOptions, Driver
+except ImportError:
+    # pyslang <= 10 exposed both at the top level.
+    from pyslang import CommandLineOptions, Driver
 
 
 def main():


### PR DESCRIPTION
pyslang bundles the slang engine and is released in lockstep with it, so the previous unpinned `uv run --with pyslang` always grabbed the latest release. v11 reorganized the bindings into submodules matching the C++ namespaces, moving Driver and CommandLineOptions into pyslang.driver, which broke run_slang.py's top-level import.

- run_slang.py: import Driver/CommandLineOptions from pyslang.driver with a fallback to the top-level names, supporting both v10 and v11.
- action.yml: add a pyslang-version input (default 11.0.0) so the pyslang (and thereby slang) version is pinned for reproducible runs.

Verified end-to-end (run_slang.py -> slang_to_rdjson.py) against pyslang 10.0.0 and 11.0.0: both produce identical rdjson output.