### PR TITLE
chore: add dependabot to automatically update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Some of the actions that we internally use for our actions are not up to date.

This PR will set up dependabot, which will automatically open PRs to update those dependency. The cadence is weekly if (any updates exist), and there is a cool down of 7 days to avoid compromised and quickly pulled actions