### PR TITLE
fix: activate dependabot also for subfolders

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/*"
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
Currently, dependabot only looks in `.github/workflows`, but it should also look into all the subfolders for `action.yml`. Tested now as well on my fork: https://github.com/fischeti/pulp-actions/pull/1