### PR TITLE
slang: Expose reviewdog filter and fail params

### DIFF
--- a/slang/action.yml
+++ b/slang/action.yml
@@ -15,6 +15,16 @@ inputs:
       description: 'Flags to pass to slang. Must at least include the file list.'
       required: true
       default: ''
+   reviewdog-filter-mode:
+    description: 'Filter diagnostics by changed lines or files.
+      One of: added, diff_context, file, nofilter.'
+    required: false
+    default: nofilter
+   reviewdog-fail-level:
+    description: 'Minimum diagnostic severity that fails the job.
+      One of: none, any, info, warning, error.'
+    required: false
+    default: none
    reviewdog-reporter:
       description: 'Reporter to use for reviewdog. Defaults to github-check.'
       required: false
@@ -54,7 +64,6 @@ runs:
 
       - name: Run reviewdog
         shell: bash
-        continue-on-error: true
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ inputs.token }}
         run: |
@@ -62,5 +71,5 @@ runs:
             | reviewdog -f=rdjson \
                 -name=${{ inputs.reviewdog-name }} \
                 -reporter=${{ inputs.reviewdog-reporter }} \
-                -filter-mode=nofilter \
-                -fail-level=error
+                -filter-mode=${{ inputs.reviewdog-filter-mode }} \
+                -fail-level=${{ inputs.reviewdog-fail-level }}


### PR DESCRIPTION
I would like to be able to configure this differently than the current default.  
For example for PRs only in common_cells I would like it to only show lints on touched files (filter=file) and I would like it to fail on warnings and errors.  
While on Push I would like it to generate it for everything but never fail.

The current default behavior should be maintained with the set defaults of never fail (it had continue-on-error: true before) and it checking all files (nofilter).